### PR TITLE
Kibana 3 and Logstash TCP appender

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Add this appender to the logback.xml configuration (note this is insecure):
 ---
 ```xml
 <appender name="stash" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
-    <destination>10.243.200.51:8091</destination>
+    <destination>10.243.200.51:8300</destination>
 
     <!-- encoder is required -->
     <encoder class="net.logstash.logback.encoder.LogstashEncoder" />

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Example:
 ```
 
 ## Kibana
-To log into kibana, go to 127.0.0.1:9200/_plugin/kibana3 on the machine you deployed your elk stack.
+To log into kibana, go to 127.0.0.1:5601 on the machine you deployed your elk stack.
 
 ## Bugs/Readme
 There are a few known bugs and the elasticsearch and kibana version are outdated.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,30 @@ Docker-compose for setting up a elk-stack, with automatic logging from docker co
 To make your logback logging java application log as json, check out https://github.com/logstash/logstash-logback-encoder
 
 ## External logging setup
+You can externally log to the ELK stack either using the logstash forwarder or using directly using a logtash tcp appender.
+
+### Using the Logstash TCP appender
+This approach is only viable on a Java application that uses logback.
+
+Add this appender to the logback.xml configuration (note this is insecure):
+---
+<appender name="stash" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
+    <destination>10.243.200.51:8091</destination>
+
+    <!-- encoder is required -->
+    <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
+</appender>
+
+<!-- ... -->
+
+<root level="INFO">
+    <!-- other appenders you might have here -->
+    <appender-ref ref="stash"/>
+</root>
+---
+
+### Using the Logstash forwarder
+
 For logging from external applications to the ELK-stack, 
 
 1. setup logstash-forwarder (https://github.com/elastic/logstash-forwarder) on the nodes you want to log from to log to port 5043 on the machine with the elk stack.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This approach is only viable on a Java application that uses logback.
 
 Add this appender to the logback.xml configuration (note this is insecure):
 ---
+```xml
 <appender name="stash" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
     <destination>10.243.200.51:8091</destination>
 
@@ -25,6 +26,7 @@ Add this appender to the logback.xml configuration (note this is insecure):
     <!-- other appenders you might have here -->
     <appender-ref ref="stash"/>
 </root>
+```
 ---
 
 ### Using the Logstash forwarder

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ You can externally log to the ELK stack either using the logstash forwarder or u
 
 ### Using the Logstash TCP appender
 This approach is only viable on a Java application that uses logback.
-
 Add this appender to the logback.xml configuration (note this is insecure):
+
 ---
 ```xml
 <appender name="stash" class="net.logstash.logback.appender.LogstashTcpSocketAppender">

--- a/docker-logstash-forwarder.yml
+++ b/docker-logstash-forwarder.yml
@@ -7,6 +7,7 @@ logstash:
     image: digitalwonderland/logstash
     ports:
         - "5043:5043"
+        - "8091:8091"
     volumes:
         - "./logstash.conf:/etc/confd/templates/logstash.conf.tmpl:ro"
     links:

--- a/docker-logstash-forwarder.yml
+++ b/docker-logstash-forwarder.yml
@@ -1,8 +1,8 @@
 elasticsearch:
-    image: digitalwonderland/elasticsearch
+    image: nshou/elasticsearch-kibana
     ports:
         - "9200:9200"
-        - "9300:9300"
+        - "5601:5601"
 logstash:
     image: digitalwonderland/logstash
     ports:

--- a/docker-logstash-forwarder.yml
+++ b/docker-logstash-forwarder.yml
@@ -7,7 +7,7 @@ logstash:
     image: digitalwonderland/logstash
     ports:
         - "5043:5043"
-        - "8091:8091"
+        - "8300:8300"
     volumes:
         - "./logstash.conf:/etc/confd/templates/logstash.conf.tmpl:ro"
     links:

--- a/logstash.conf
+++ b/logstash.conf
@@ -8,7 +8,8 @@ input {
     port => 1514
   }
   tcp {
-    port => 3333
+    port => 8091
+    codec => json_lines
   }
 }
 

--- a/logstash.conf
+++ b/logstash.conf
@@ -8,7 +8,7 @@ input {
     port => 1514
   }
   tcp {
-    port => 8091
+    port => 8300
     codec => json_lines
   }
 }


### PR DESCRIPTION
Uses another Elasticsearch image that includes newer version of Kibana 3.
Configured port of Logstash TCP to match port of Logstash and codec to receive json output from Logstash TCP appender.